### PR TITLE
ユーザー詳細 ページ機能

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+
+  def index
+    
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
-
-  def index
-    
+  def show
+    @user = User.find(params[:id])
+    @prototypes = @user.prototypes
   end
+
+
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -2,6 +2,8 @@ class Prototype < ApplicationRecord
   validates :name, presence: true
   validates :catchcopy, presence: true
   validates :concept, presence: true
+  validates :image, presence: true
+
    has_one_attached :image
    belongs_to :user
 

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catchcopy %>
     </p>
-    <%= link_to prototype.user.name, root_path, class: :card__user %>
+    <%= link_to prototype.user.name, user_path(prototype.user.id), class: :card__user %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,34 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.job %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+            <%= render partial: "/prototypes/prototype", collection: @prototypes %>
+
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   resources :prototypes
   devise_for :users
   root to:"prototypes#index"
+  resources :users, only: :show
+
 end


### PR DESCRIPTION
#what
ユーザー詳細ページの実装
〇コントローラー：userコントローラーの作成　showアクションの定義
〇showビュー：user詳細の表示、投稿一覧の表示
〇ルーティング：userコントローラーshowアクションのルーティングの設定
#why
ログインの有無にかかわらずユーザーページには推移できるように設定しました。ユーザーページより、詳細画面に推移(編集権限の有無によって内容が異なる)できるようになっています。
https://github.com/ricchandes/protospace-151-gotoseoul/assets/136784375/257f7881-a3b0-4051-a68b-39fe75642386


https://github.com/ricchandes/protospace-151-gotoseoul/assets/136784375/bb02dc4e-a707-4344-8f2f-cb26db0aa658

